### PR TITLE
NH-108360 - GitHub action follow up

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+### Description of changes:
+<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
+
+
+### Related issues #
+[NH-?????](https://swicloud.atlassian.net/browse/NH-?????)

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -19,11 +19,11 @@ jobs:
       # Needed for GitHub OIDC token if publish_results is true
       id-token: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+      - uses: ossf/scorecard-action@v2.4.1
         with:
           results_file: results.sarif
           results_format: sarif
@@ -33,7 +33,7 @@ jobs:
       # uploads of run results in SARIF format to the repository Actions tab.
       # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
       - name: "Upload artifact"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions: read-all
+
 jobs:
   php:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Used tag instead of hash for checkout / scorecard / upload artifact action
- Added `permissions: read-all` in php.yml
- Added pull_request_template.md

https://swicloud.atlassian.net/browse/NH-108360