### PR TITLE
NH-108360 GHA: Added update hook for packagist

### DIFF
--- a/.github/workflows/packagist.yml
+++ b/.github/workflows/packagist.yml
@@ -1,0 +1,17 @@
+name: Packagist
+
+on:
+  push:
+    branches: [ "main" ]
+    tags:
+      - '**'
+
+permissions: read-all
+
+jobs:
+  packagist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update
+        run: |
+          curl -XPOST -H'content-type:application/json' ${{ secrets.UPDATE_PACKAGE_HOOK }} -d'{"repository":{"url":"https://github.com/solarwinds/apm-php"}}'


### PR DESCRIPTION
### Description of changes:
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Solarwinds org doesn't allow setting up a GitHub web hook to auto update package. Now we need to update it manually

### Related issues #
[NH-108360](https://swicloud.atlassian.net/browse/NH-108360)

[NH-108360]: https://swicloud.atlassian.net/browse/NH-108360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ