### PR TITLE
NH-108341 - Sync the dependencies with upstream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,11 +42,23 @@
   },
   "require": {
     "php": "^8.1",
+    "google/protobuf": "^3.22 || ^4.0",
+    "nyholm/psr7-server": "^1.1",
     "open-telemetry/sdk": "^1.2",
     "open-telemetry/sdk-configuration": "^0.0.8",
     "open-telemetry/sem-conv": "^1.30",
     "open-telemetry/api": "^1.2",
     "open-telemetry/exporter-otlp": "^1.2",
+    "php-http/discovery": "^1.14",
+    "psr/http-client": "^1.0",
+    "psr/http-client-implementation": "^1.0",
+    "psr/http-factory-implementation": "^1.0",
+    "psr/http-message": "^1.0.1|^2.0",
+    "psr/log": "^1.1|^2.0|^3.0",
+    "ramsey/uuid": "^3.0 || ^4.0",
+    "symfony/config": "^5.4 || ^6.4 || ^7.0",
+    "symfony/polyfill-mbstring": "^1.23",
+    "symfony/polyfill-php82": "^1.26",
     "tbachert/spi": "^1.0.3"
   },
   "config": {


### PR DESCRIPTION
### Description of changes:
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Synced the dependencies with upstream so that when using otlp exporter, we won't get PSR 18 http client implementation missing error. 

### Related issues #
[NH-108341](https://swicloud.atlassian.net/browse/NH-108341)

[NH-108341]: https://swicloud.atlassian.net/browse/NH-108341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ