### PR TITLE
NH-110416 Use RequestFactoryInterface instead of the concrete file_get_contents in http sampler

### DIFF
--- a/src/Trace/SwoSamplerFactory.php
+++ b/src/Trace/SwoSamplerFactory.php
@@ -46,7 +46,7 @@ class SwoSamplerFactory
                     $collector = Configuration::getString(SolarwindsEnv::SW_APM_COLLECTOR, self::DEFAULT_APM_COLLECTOR);
                     $serviceKey = Configuration::getString(SolarwindsEnv::SW_APM_SERVICE_KEY, self::DUMMY_SERVICE_KEY);
                     [$token, $service] = explode(':', $serviceKey);
-                    $http = new HttpSampler(null, new SolarwindsConfiguration(true, $service, 'https://' . $collector, ['Authorization: Bearer ' . $token,], true, true, null, []), null);
+                    $http = new HttpSampler(null, new SolarwindsConfiguration(true, $service, 'https://' . $collector, ['Authorization' => 'Bearer ' . $token], true, true, null, []), null);
 
                     return new ParentBased($http, $http, $http);
                 case self::VALUE_SOLARWINDS_JSON:

--- a/tests/Unit/Trace/Sampler/HttpSamplerTest.php
+++ b/tests/Unit/Trace/Sampler/HttpSamplerTest.php
@@ -23,7 +23,7 @@ class HttpSamplerTest extends TestCase
         }
         [$token, $service] = explode(':', $serviceKey);
         $spanExporter = new InMemoryExporter();
-        $sampler = new HttpSampler(null, new Configuration(true, $service, 'https://apm.collector.na-01.cloud.solarwinds.com', ['Authorization: Bearer ' . $token,], true, true, null, []), null);
+        $sampler = new HttpSampler(null, new Configuration(true, $service, 'https://apm.collector.na-01.cloud.solarwinds.com', ['Authorization' => 'Bearer ' . $token], true, true, null, []), null);
         $tracerProvider = TracerProvider::builder()->addSpanProcessor(new SimpleSpanProcessor($spanExporter))->setSampler($sampler)->build();
         $tracer = $tracerProvider->getTracer('test');
         // $sampler->waitUntilReady(1000);
@@ -41,7 +41,7 @@ class HttpSamplerTest extends TestCase
     public function test_invalid_service_key_does_not_sample_created_spans(): void
     {
         $spanExporter = new InMemoryExporter();
-        $sampler = new HttpSampler(null, new Configuration(true, 'phpunit', 'https://apm.collector.na-01.cloud.solarwinds.com', ['Authorization: Bearer oh no',], true, true, null, []), null);
+        $sampler = new HttpSampler(null, new Configuration(true, 'phpunit', 'https://apm.collector.na-01.cloud.solarwinds.com', ['Authorization' => 'Bearer oh no'], true, true, null, []), null);
         $tracerProvider = TracerProvider::builder()->addSpanProcessor(new SimpleSpanProcessor($spanExporter))->setSampler($sampler)->build();
         $tracer = $tracerProvider->getTracer('test');
         // $sampler->waitUntilReady(1000);
@@ -60,7 +60,7 @@ class HttpSamplerTest extends TestCase
         }
         [$token, $service] = explode(':', $serviceKey);
         $spanExporter = new InMemoryExporter();
-        $sampler = new HttpSampler(null, new Configuration(true, $service, 'https://collector.invalid', ['Authorization: Bearer ' . $token,], true, true, null, []), null);
+        $sampler = new HttpSampler(null, new Configuration(true, $service, 'https://collector.invalid', ['Authorization' => 'Bearer ' . $token,], true, true, null, []), null);
         $tracerProvider = TracerProvider::builder()->addSpanProcessor(new SimpleSpanProcessor($spanExporter))->setSampler($sampler)->build();
         $tracer = $tracerProvider->getTracer('test');
         // $sampler->waitUntilReady(1000);

--- a/tests/Unit/Trace/Sampler/HttpSamplerTest.php
+++ b/tests/Unit/Trace/Sampler/HttpSamplerTest.php
@@ -26,7 +26,6 @@ class HttpSamplerTest extends TestCase
         $sampler = new HttpSampler(null, new Configuration(true, $service, 'https://apm.collector.na-01.cloud.solarwinds.com', ['Authorization' => 'Bearer ' . $token], true, true, null, []), null);
         $tracerProvider = TracerProvider::builder()->addSpanProcessor(new SimpleSpanProcessor($spanExporter))->setSampler($sampler)->build();
         $tracer = $tracerProvider->getTracer('test');
-        // $sampler->waitUntilReady(1000);
         $span = $tracer->spanBuilder('test')->startSpan();
         $this->assertTrue($span->isRecording());
         $span->end();
@@ -44,7 +43,6 @@ class HttpSamplerTest extends TestCase
         $sampler = new HttpSampler(null, new Configuration(true, 'phpunit', 'https://apm.collector.na-01.cloud.solarwinds.com', ['Authorization' => 'Bearer oh no'], true, true, null, []), null);
         $tracerProvider = TracerProvider::builder()->addSpanProcessor(new SimpleSpanProcessor($spanExporter))->setSampler($sampler)->build();
         $tracer = $tracerProvider->getTracer('test');
-        // $sampler->waitUntilReady(1000);
         $span = $tracer->spanBuilder('test')->startSpan();
         $this->assertFalse($span->isRecording());
         $span->end();
@@ -63,7 +61,6 @@ class HttpSamplerTest extends TestCase
         $sampler = new HttpSampler(null, new Configuration(true, $service, 'https://collector.invalid', ['Authorization' => 'Bearer ' . $token,], true, true, null, []), null);
         $tracerProvider = TracerProvider::builder()->addSpanProcessor(new SimpleSpanProcessor($spanExporter))->setSampler($sampler)->build();
         $tracer = $tracerProvider->getTracer('test');
-        // $sampler->waitUntilReady(1000);
         $span = $tracer->spanBuilder('test')->startSpan();
         $this->assertFalse($span->isRecording());
         $span->end();


### PR DESCRIPTION
### Description of changes:
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
- Used Psr17 and Psr18 instead of concrete file_get_contents to get https request

### Related issues #
[NH-110416](https://swicloud.atlassian.net/browse/NH-110416)

[NH-110416]: https://swicloud.atlassian.net/browse/NH-110416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ