### PR TITLE
NH-108337 metrics support

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,8 @@
+PHP_USER=php
+XDEBUG_MODE=debug
+PHP_CS_FIXER_IGNORE_ENV=true
+#docker-compose or "docker compose" for v1/v2 respectively, note that v1 support ends 06/2023
+DOCKER_COMPOSE=docker compose
+#Solarwinds specific service key
+# see https://documentation.solarwinds.com/en/success_center/observability/content/configure/services/php/configure.htm
+SW_APM_SERVICE_KEY=token:your-service

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -32,6 +32,7 @@
         <DeprecatedConstant>
             <errorLevel type="suppress">
                 <file name="./src/Trace/Sampler/Sampler.php" />
+                <file name="./src/Trace/SpanProcessor/ResponseTimeSpanProcessor.php" />
             </errorLevel>
         </DeprecatedConstant>
     </issueHandlers>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -36,5 +36,10 @@
                 <directory name="./tests/" />
             </errorLevel>
         </DeprecatedConstant>
+        <PossiblyInvalidArgument>
+            <errorLevel type="suppress">
+                <file name="./src/Trace/SpanProcessor/ResponseTimeSpanProcessor.php" />
+            </errorLevel>
+        </PossiblyInvalidArgument>
     </issueHandlers>
 </psalm>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -33,6 +33,7 @@
             <errorLevel type="suppress">
                 <file name="./src/Trace/Sampler/Sampler.php" />
                 <file name="./src/Trace/SpanProcessor/ResponseTimeSpanProcessor.php" />
+                <directory name="./tests/" />
             </errorLevel>
         </DeprecatedConstant>
     </issueHandlers>

--- a/src/SdkAutoloader.php
+++ b/src/SdkAutoloader.php
@@ -39,6 +39,7 @@ use OpenTelemetry\SDK\Trace\ExporterFactory;
 use OpenTelemetry\SDK\Trace\SpanProcessorFactory;
 use OpenTelemetry\SDK\Trace\TracerProviderBuilder;
 use RuntimeException;
+use Solarwinds\ApmPhp\Trace\SpanProcessor\ResponseTimeSpanProcessor;
 use Solarwinds\ApmPhp\Trace\SpanProcessor\TransactionNameSpanProcessor;
 use Solarwinds\ApmPhp\Trace\SwoSamplerFactory;
 use Throwable;
@@ -96,10 +97,11 @@ class SdkAutoloader
         $meterProvider = (new MeterProviderFactory())->create($resource);
         $spanProcessor = (new SpanProcessorFactory())->create($exporter, $emitMetrics ? $meterProvider : null);
         $tracerProvider = (new TracerProviderBuilder())
-            ->addSpanProcessor(TransactionNameSpanProcessor::getInstance())      // Transaction Name Span Processor
+            ->addSpanProcessor(TransactionNameSpanProcessor::getInstance())      // Transaction Name Span Processor (Used singleton due to the transaction name pool)
+            ->addSpanProcessor(new ResponseTimeSpanProcessor($meterProvider))    // Response Time Span Processor
             ->addSpanProcessor($spanProcessor)                                   // Otel Span Processors
             ->setResource($resource)
-            ->setSampler((new SwoSamplerFactory())->create())
+            ->setSampler((new SwoSamplerFactory())->create($meterProvider))
             ->build();
 
         $loggerProvider = (new LoggerProviderFactory())->create($emitMetrics ? $meterProvider : null, $resource);

--- a/src/Trace/Sampler/Counters.php
+++ b/src/Trace/Sampler/Counters.php
@@ -24,12 +24,13 @@ class Counters
     ) {
         $provider = $meterProvider ?? Globals::meterProvider();
         $this->meter = $provider->getMeter('sw.apm.sampling.metrics');
-        $this->request_count = $this->meter->createCounter('trace.service.request_count', '{request}', 'Count of all requests to the service');
-        $this->sample_count = $this->meter->createCounter('trace.service.samplecount', '{request}', 'Count of sampled requests');
-        $this->trace_count = $this->meter->createCounter('trace.service.tracecount', '{trace}', 'Count of traces generated from requests');
-        $this->through_trace_count = $this->meter->createCounter('trace.service.through_trace_count', '{request}', 'Count of requests that carried valid upstream sampling decision');
-        $this->triggered_trace_count = $this->meter->createCounter('trace.service.triggered_trace_count', '{trace}', 'Count of trigger traces');
-        $this->token_bucket_exhaustion_count = $this->meter->createCounter('trace.service.tokenbucket_exhaustion_count', '{request}', 'Count of requests that were not traced due to token bucket exhaustion');
+        $this->request_count = $this->meter->createCounter('trace.service.request_count', '{request}', 'Count of all requests.');
+        $this->sample_count = $this->meter->createCounter('trace.service.samplecount', '{request}', 'Count of requests that went through sampling, which excludes those with a valid upstream decision or trigger traced.');
+        $this->through_trace_count = $this->meter->createCounter('trace.service.through_trace_count', '{request}', 'Count of requests with a valid upstream decision, thus passed through sampling.');
+        $this->token_bucket_exhaustion_count = $this->meter->createCounter('trace.service.tokenbucket_exhaustion_count', '{request}', 'Count of requests that were not traced due to token bucket rate limiting.');
+        $this->trace_count = $this->meter->createCounter('trace.service.tracecount', '{trace}', 'Count of all traces.');
+        $this->triggered_trace_count = $this->meter->createCounter('trace.service.triggered_trace_count', '{trace}', 'Count of triggered traces.');
+
     }
 
     public function getRequestCount(): CounterInterface

--- a/src/Trace/Sampler/Counters.php
+++ b/src/Trace/Sampler/Counters.php
@@ -24,12 +24,12 @@ class Counters
     ) {
         $provider = $meterProvider ?? Globals::meterProvider();
         $this->meter = $provider->getMeter('sw.apm.sampling.metrics');
-        $this->request_count = $this->meter->createCounter('trace.service.request_count');
-        $this->sample_count = $this->meter->createCounter('trace.service.samplecount');
-        $this->trace_count = $this->meter->createCounter('trace.service.tracecount');
-        $this->through_trace_count = $this->meter->createCounter('trace.service.through_trace_count');
-        $this->triggered_trace_count = $this->meter->createCounter('trace.service.triggered_trace_count');
-        $this->token_bucket_exhaustion_count = $this->meter->createCounter('trace.service.tokenbucket_exhaustion_count');
+        $this->request_count = $this->meter->createCounter('trace.service.request_count', '{request}', 'Count of all requests to the service');
+        $this->sample_count = $this->meter->createCounter('trace.service.samplecount', '{request}', 'Count of sampled requests');
+        $this->trace_count = $this->meter->createCounter('trace.service.tracecount', '{trace}', 'Count of traces generated from requests');
+        $this->through_trace_count = $this->meter->createCounter('trace.service.through_trace_count', '{request}', 'Count of requests that carried valid upstream sampling decision');
+        $this->triggered_trace_count = $this->meter->createCounter('trace.service.triggered_trace_count', '{trace}', 'Count of trigger traces');
+        $this->token_bucket_exhaustion_count = $this->meter->createCounter('trace.service.tokenbucket_exhaustion_count', '{request}', 'Count of requests that were not traced due to token bucket exhaustion');
     }
 
     public function getRequestCount(): CounterInterface

--- a/src/Trace/SpanProcessor/ResponseTimeSpanProcessor.php
+++ b/src/Trace/SpanProcessor/ResponseTimeSpanProcessor.php
@@ -27,8 +27,14 @@ class ResponseTimeSpanProcessor extends NoopSpanProcessor implements SpanProcess
         $this->histogram = $meter->createHistogram(
             'trace.service.response_time',
             'ms',
-            'Duration of each entry span for the service, typically meaning the time taken to process an inbound request.');
+            'Duration of each entry span for the service, typically meaning the time taken to process an inbound request.'
+        );
     }
+
+    /**
+     * Still need the deprecated class constant
+     * @phan-suppress PhanDeprecatedClassConstant
+     */
     public function onEnd(ReadableSpanInterface $span): void
     {
         $parentSpanContext = $span->getParentContext();
@@ -51,7 +57,7 @@ class ResponseTimeSpanProcessor extends NoopSpanProcessor implements SpanProcess
         }
         foreach ($copy as $attribute) {
             if ($span->getAttribute($attribute) !== null) {
-                $attributes[$attribute] = $span->getAttribute($attribute);
+                $attributes[$attribute] = (string) ($span->getAttribute($attribute));
             }
         }
         $this->logDebug('Recording response time: ' . $durationMs . 'ms, ' . json_encode($attributes));

--- a/src/Trace/SpanProcessor/ResponseTimeSpanProcessor.php
+++ b/src/Trace/SpanProcessor/ResponseTimeSpanProcessor.php
@@ -34,7 +34,6 @@ class ResponseTimeSpanProcessor extends NoopSpanProcessor implements SpanProcess
     /**
      * Still need the deprecated class constant
      * @phan-suppress PhanDeprecatedClassConstant
-     * @psalm-suppress PossiblyInvalidArgument
      */
     public function onEnd(ReadableSpanInterface $span): void
     {

--- a/src/Trace/SpanProcessor/ResponseTimeSpanProcessor.php
+++ b/src/Trace/SpanProcessor/ResponseTimeSpanProcessor.php
@@ -27,7 +27,7 @@ class ResponseTimeSpanProcessor extends NoopSpanProcessor implements SpanProcess
         $this->histogram = $meter->createHistogram(
             'trace.service.response_time',
             'ms',
-            'measures the duration inbound HTTP requests');
+            'Duration of each entry span for the service, typically meaning the time taken to process an inbound request.');
     }
     public function onEnd(ReadableSpanInterface $span): void
     {

--- a/src/Trace/SpanProcessor/ResponseTimeSpanProcessor.php
+++ b/src/Trace/SpanProcessor/ResponseTimeSpanProcessor.php
@@ -34,6 +34,7 @@ class ResponseTimeSpanProcessor extends NoopSpanProcessor implements SpanProcess
     /**
      * Still need the deprecated class constant
      * @phan-suppress PhanDeprecatedClassConstant
+     * @psalm-suppress PossiblyInvalidArgument
      */
     public function onEnd(ReadableSpanInterface $span): void
     {
@@ -55,9 +56,10 @@ class ResponseTimeSpanProcessor extends NoopSpanProcessor implements SpanProcess
                 TraceAttributes::HTTP_STATUS_CODE,
             ]);
         }
-        foreach ($copy as $attribute) {
-            if ($span->getAttribute($attribute) !== null) {
-                $attributes[$attribute] = (string) ($span->getAttribute($attribute));
+        foreach ($copy as $key) {
+            $value = $span->getAttribute($key);
+            if ($value !== null) {
+                $attributes[$key] = $value;
             }
         }
         $this->logDebug('Recording response time: ' . $durationMs . 'ms, ' . json_encode($attributes));

--- a/src/Trace/SpanProcessor/ResponseTimeSpanProcessor.php
+++ b/src/Trace/SpanProcessor/ResponseTimeSpanProcessor.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarwinds\ApmPhp\Trace\SpanProcessor;
+
+use OpenTelemetry\API\Behavior\LogsMessagesTrait;
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Metrics\HistogramInterface;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\SDK\Metrics\MeterProviderInterface;
+use OpenTelemetry\SDK\Trace\ReadableSpanInterface;
+use OpenTelemetry\SDK\Trace\SpanProcessor\NoopSpanProcessor;
+use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
+use OpenTelemetry\SemConv\TraceAttributes;
+
+class ResponseTimeSpanProcessor extends NoopSpanProcessor implements SpanProcessorInterface
+{
+    use LogsMessagesTrait;
+    private HistogramInterface $histogram;
+
+    public function __construct(?MeterProviderInterface $meterProvider = null)
+    {
+        $meterProvider = $meterProvider ?? Globals::meterProvider();
+        $meter = $meterProvider->getMeter('sw.apm.request.metrics');
+        $this->histogram = $meter->createHistogram(
+            'trace.service.response_time',
+            'ms',
+            'measures the duration inbound HTTP requests');
+    }
+    public function onEnd(ReadableSpanInterface $span): void
+    {
+        $parentSpanContext = $span->getParentContext();
+        if ($parentSpanContext->isValid() && !$parentSpanContext->isRemote()) {
+            return;
+        }
+        $durationMs = $span->getDuration() / 1000_000; // ns converts to ms
+        $spanData = $span->toSpanData();
+        $attributes = [
+            'sw.is_error' => $spanData->getStatus()->getCode() === StatusCode::STATUS_ERROR,
+        ];
+        $copy = [TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE];
+        if ($span->getKind() === SpanKind::KIND_SERVER) {
+            $copy = array_merge($copy, [
+                TraceAttributes::HTTP_REQUEST_METHOD,
+                TraceAttributes::HTTP_RESPONSE_STATUS_CODE,
+                TraceAttributes::HTTP_METHOD,
+                TraceAttributes::HTTP_STATUS_CODE,
+            ]);
+        }
+        foreach ($copy as $attribute) {
+            if ($span->getAttribute($attribute) !== null) {
+                $attributes[$attribute] = $span->getAttribute($attribute);
+            }
+        }
+        $this->logDebug('Recording response time: ' . $durationMs . 'ms, ' . json_encode($attributes));
+        $this->histogram->record($durationMs, $attributes);
+    }
+}

--- a/src/Trace/SwoSamplerFactory.php
+++ b/src/Trace/SwoSamplerFactory.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use OpenTelemetry\SDK\Common\Configuration\Configuration;
 use OpenTelemetry\SDK\Common\Configuration\KnownValues as Values;
 use OpenTelemetry\SDK\Common\Configuration\Variables as Env;
+use OpenTelemetry\SDK\Metrics\MeterProviderInterface;
 use OpenTelemetry\SDK\Trace\Sampler\AlwaysOffSampler;
 use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
 use OpenTelemetry\SDK\Trace\Sampler\ParentBased;
@@ -25,7 +26,7 @@ class SwoSamplerFactory
     private const DEFAULT_APM_COLLECTOR = 'apm.collector.na-01.cloud.solarwinds.com';
     private const DUMMY_SERVICE_KEY = 'your-token:default-service';
 
-    public function create(): SamplerInterface
+    public function create(?MeterProviderInterface $meterProvider = null): SamplerInterface
     {
         $name = Configuration::getString(Env::OTEL_TRACES_SAMPLER);
 
@@ -43,7 +44,7 @@ class SwoSamplerFactory
                     $collector = Configuration::getString(SolarwindsEnv::SW_APM_COLLECTOR, self::DEFAULT_APM_COLLECTOR);
                     $serviceKey = Configuration::getString(SolarwindsEnv::SW_APM_SERVICE_KEY, self::DUMMY_SERVICE_KEY);
                     [$token, $service] = explode(':', $serviceKey);
-                    $http = new HttpSampler(null, new SolarwindsConfiguration(true, $service, 'https://' . $collector, ['Authorization' => 'Bearer ' . $token], true, true, null, []), null);
+                    $http = new HttpSampler($meterProvider, new SolarwindsConfiguration(true, $service, 'https://' . $collector, ['Authorization' => 'Bearer ' . $token], true, true, null, []), null);
 
                     return new ParentBased($http, $http, $http);
             }

--- a/tests/Unit/Trace/SpanProcessor/ResponseTimeSpanProcessorTest.php
+++ b/tests/Unit/Trace/SpanProcessor/ResponseTimeSpanProcessorTest.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solarwinds\ApmPhp\Tests\Unit\Trace\SpanProcessor;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use Mockery\MockInterface;
+use OpenTelemetry\API\Trace\SpanContext;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\API\Trace\TraceFlags;
+use OpenTelemetry\SDK\Metrics\Data\Histogram;
+use OpenTelemetry\SDK\Metrics\MeterProviderBuilder;
+use OpenTelemetry\SDK\Metrics\MetricExporter\InMemoryExporter;
+use OpenTelemetry\SDK\Metrics\MetricReader\ExportingReader;
+use OpenTelemetry\SDK\Metrics\MetricReaderInterface;
+use OpenTelemetry\SDK\Trace\RandomIdGenerator;
+use OpenTelemetry\SDK\Trace\ReadableSpanInterface;
+use OpenTelemetry\SDK\Trace\SpanDataInterface;
+use OpenTelemetry\SDK\Trace\StatusData;
+use OpenTelemetry\SemConv\TraceAttributes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Solarwinds\ApmPhp\Trace\SpanProcessor\ResponseTimeSpanProcessor;
+use Solarwinds\ApmPhp\Trace\SpanProcessor\TransactionNameSpanProcessor;
+
+#[CoversClass(ResponseTimeSpanProcessor::class)]
+class ResponseTimeSpanProcessorTest extends MockeryTestCase
+{
+    private ResponseTimeSpanProcessor $responseTimeSpanProcessor;
+    private InMemoryExporter $exporter;
+    private MetricReaderInterface $reader;
+    /** @var MockInterface&ReadableSpanInterface */
+    private $readableSpan;
+
+    protected function setUp(): void
+    {
+        $this->readableSpan = Mockery::mock(ReadableSpanInterface::class);
+        $this->exporter = new InMemoryExporter();
+        $this->reader = new ExportingReader($this->exporter);
+        $meterProvider = (new MeterProviderBuilder())->addReader($this->reader)->build();
+        $this->responseTimeSpanProcessor = new ResponseTimeSpanProcessor($meterProvider);
+    }
+    public function test_span_ok(): void
+    {
+        $this->readableSpan->expects('getParentContext')->andReturn(SpanContext::getInvalid());
+        $this->readableSpan->expects('getDuration')->andReturn(123456789);
+        $spanData = Mockery::mock(SpanDataInterface::class);
+        $spanData->expects('getStatus')->andReturn(StatusData::create(StatusCode::STATUS_OK, 'ok'));
+        $this->readableSpan->expects('toSpanData')->andReturn($spanData);
+        $this->readableSpan->expects('getKind')->andReturn(SpanKind::KIND_SERVER);
+        $this->readableSpan->expects('getAttribute')->with(TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE)->andReturn('transaction');
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_REQUEST_METHOD)->andReturn('GET');
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_RESPONSE_STATUS_CODE)->andReturn(200);
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_METHOD)->andReturnNull();
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_STATUS_CODE)->andReturnNull();
+        $this->responseTimeSpanProcessor->onEnd($this->readableSpan);
+        $this->reader->collect();
+        $metrics = $this->exporter->Collect();
+        // Check histogram
+        $this->assertCount(1, $metrics);
+        foreach ($metrics as $metric) {
+            $this->assertEquals('trace.service.response_time', $metric->name);
+            $this->assertEquals('ms', $metric->unit);
+            if ($metric->data instanceof Histogram) {
+                $this->assertEquals('Delta', $metric->data->temporality);
+                $this->assertCount(1, $metric->data->dataPoints);
+                foreach ($metric->data->dataPoints as $dataPoint) {
+                    $this->assertEquals(123.456789, $dataPoint->sum);
+                    $attributes = [];
+                    foreach ($dataPoint->attributes as $key => $value) {
+                        $attributes[$key] = $value;
+                    }
+                    $this->assertFalse($attributes['sw.is_error'] ?? true);
+                    $this->assertEquals('transaction', $attributes[TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE] ?? '');
+                    $this->assertEquals('GET', $attributes[TraceAttributes::HTTP_REQUEST_METHOD] ?? '');
+                    $this->assertEquals(200, $attributes[TraceAttributes::HTTP_RESPONSE_STATUS_CODE] ?? '');
+                    $this->assertArrayNotHasKey(TraceAttributes::HTTP_METHOD, $attributes);
+                    $this->assertArrayNotHasKey(TraceAttributes::HTTP_STATUS_CODE, $attributes);
+                }
+            }
+        }
+    }
+    public function test_span_ok_spankind(): void
+    {
+        $this->readableSpan->expects('getParentContext')->andReturn(SpanContext::getInvalid());
+        $this->readableSpan->expects('getDuration')->andReturn(123456789);
+        $spanData = Mockery::mock(SpanDataInterface::class);
+        $spanData->expects('getStatus')->andReturn(StatusData::create(StatusCode::STATUS_OK, 'ok'));
+        $this->readableSpan->expects('toSpanData')->andReturn($spanData);
+        $this->readableSpan->expects('getKind')->andReturn(SpanKind::KIND_CLIENT);
+        $this->readableSpan->expects('getAttribute')->with(TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE)->andReturn('transaction');
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_REQUEST_METHOD)->never();
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_RESPONSE_STATUS_CODE)->never();
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_METHOD)->never();
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_STATUS_CODE)->never();
+        $this->responseTimeSpanProcessor->onEnd($this->readableSpan);
+        $this->reader->collect();
+        $metrics = $this->exporter->Collect();
+        // Check histogram
+        $this->assertCount(1, $metrics);
+        foreach ($metrics as $metric) {
+            $this->assertEquals('trace.service.response_time', $metric->name);
+            $this->assertEquals('ms', $metric->unit);
+            if ($metric->data instanceof Histogram) {
+                $this->assertEquals('Delta', $metric->data->temporality);
+                $this->assertCount(1, $metric->data->dataPoints);
+                foreach ($metric->data->dataPoints as $dataPoint) {
+                    $this->assertEquals(123.456789, $dataPoint->sum);
+                    $attributes = [];
+                    foreach ($dataPoint->attributes as $key => $value) {
+                        $attributes[$key] = $value;
+                    }
+                    $this->assertFalse($attributes['sw.is_error'] ?? true);
+                    $this->assertEquals('transaction', $attributes[TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE] ?? '');
+                    $this->assertArrayNotHasKey(TraceAttributes::HTTP_REQUEST_METHOD, $attributes);
+                    $this->assertArrayNotHasKey(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $attributes);
+                    $this->assertArrayNotHasKey(TraceAttributes::HTTP_METHOD, $attributes);
+                    $this->assertArrayNotHasKey(TraceAttributes::HTTP_STATUS_CODE, $attributes);
+                }
+            }
+        }
+    }
+    public function test_span_ok_depreciated_fields(): void
+    {
+        $this->readableSpan->expects('getParentContext')->andReturn(SpanContext::getInvalid());
+        $this->readableSpan->expects('getDuration')->andReturn(123456789);
+        $spanData = Mockery::mock(SpanDataInterface::class);
+        $spanData->expects('getStatus')->andReturn(StatusData::create(StatusCode::STATUS_OK, 'ok'));
+        $this->readableSpan->expects('toSpanData')->andReturn($spanData);
+        $this->readableSpan->expects('getKind')->andReturn(SpanKind::KIND_SERVER);
+        $this->readableSpan->expects('getAttribute')->with(TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE)->andReturn('transaction');
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_METHOD)->andReturn('GET');
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_STATUS_CODE)->andReturn(200);
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_REQUEST_METHOD)->andReturnNull();
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_RESPONSE_STATUS_CODE)->andReturnNull();
+        $this->responseTimeSpanProcessor->onEnd($this->readableSpan);
+        $this->reader->collect();
+        $metrics = $this->exporter->Collect();
+        // Check histogram
+        $this->assertCount(1, $metrics);
+        foreach ($metrics as $metric) {
+            $this->assertEquals('trace.service.response_time', $metric->name);
+            $this->assertEquals('ms', $metric->unit);
+            if ($metric->data instanceof Histogram) {
+                $this->assertEquals('Delta', $metric->data->temporality);
+                $this->assertCount(1, $metric->data->dataPoints);
+                foreach ($metric->data->dataPoints as $dataPoint) {
+                    $this->assertEquals(123.456789, $dataPoint->sum);
+                    $attributes = [];
+                    foreach ($dataPoint->attributes as $key => $value) {
+                        $attributes[$key] = $value;
+                    }
+                    $this->assertFalse($attributes['sw.is_error'] ?? true);
+                    $this->assertEquals('transaction', $attributes[TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE] ?? '');
+                    $this->assertEquals('GET', $attributes[TraceAttributes::HTTP_METHOD] ?? '');
+                    $this->assertEquals(200, $attributes[TraceAttributes::HTTP_STATUS_CODE] ?? '');
+                    $this->assertArrayNotHasKey(TraceAttributes::HTTP_REQUEST_METHOD, $attributes);
+                    $this->assertArrayNotHasKey(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $attributes);
+                }
+            }
+        }
+    }
+    public function test_local_parent(): void
+    {
+        $generator = new RandomIdGenerator();
+        $validLocalParentContext = SpanContext::create(
+            $generator->generateTraceId(),
+            $generator->generateSpanId(),
+            TraceFlags::SAMPLED
+        );
+        $this->readableSpan->expects('getParentContext')->andReturn($validLocalParentContext);
+        $this->responseTimeSpanProcessor->onEnd($this->readableSpan);
+        $this->reader->collect();
+        $metrics = $this->exporter->Collect();
+        // Check histogram
+        $this->assertCount(1, $metrics);
+        foreach ($metrics as $metric) {
+            $this->assertEquals('trace.service.response_time', $metric->name);
+            $this->assertEquals('ms', $metric->unit);
+            if ($metric->data instanceof Histogram) {
+                $this->assertEquals('Delta', $metric->data->temporality);
+                $this->assertCount(0, $metric->data->dataPoints);
+            }
+        }
+    }
+    public function test_remote_parent_ok(): void
+    {
+        $generator = new RandomIdGenerator();
+        $validRemoteParentContext = SpanContext::createFromRemoteParent(
+            $generator->generateTraceId(),
+            $generator->generateSpanId(),
+            TraceFlags::SAMPLED
+        );
+        $this->readableSpan->expects('getParentContext')->andReturn($validRemoteParentContext);
+        $this->readableSpan->expects('getDuration')->andReturn(123456789);
+        $spanData = Mockery::mock(SpanDataInterface::class);
+        $spanData->expects('getStatus')->andReturn(StatusData::create(StatusCode::STATUS_OK, 'ok'));
+        $this->readableSpan->expects('toSpanData')->andReturn($spanData);
+        $this->readableSpan->expects('getKind')->andReturn(SpanKind::KIND_SERVER);
+        $this->readableSpan->expects('getAttribute')->with(TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE)->andReturn('transaction');
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_REQUEST_METHOD)->andReturn('GET');
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_RESPONSE_STATUS_CODE)->andReturn(200);
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_METHOD)->andReturnNull();
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_STATUS_CODE)->andReturnNull();
+        $this->responseTimeSpanProcessor->onEnd($this->readableSpan);
+        $this->reader->collect();
+        $metrics = $this->exporter->Collect();
+        // Check histogram
+        $this->assertCount(1, $metrics);
+        foreach ($metrics as $metric) {
+            $this->assertEquals('trace.service.response_time', $metric->name);
+            $this->assertEquals('ms', $metric->unit);
+            if ($metric->data instanceof Histogram) {
+                $this->assertEquals('Delta', $metric->data->temporality);
+                $this->assertCount(1, $metric->data->dataPoints);
+                foreach ($metric->data->dataPoints as $dataPoint) {
+                    $this->assertEquals(123.456789, $dataPoint->sum);
+                    $attributes = [];
+                    foreach ($dataPoint->attributes as $key => $value) {
+                        $attributes[$key] = $value;
+                    }
+                    $this->assertFalse($attributes['sw.is_error'] ?? true);
+                    $this->assertEquals('transaction', $attributes[TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE] ?? '');
+                    $this->assertEquals('GET', $attributes[TraceAttributes::HTTP_REQUEST_METHOD] ?? '');
+                    $this->assertEquals(200, $attributes[TraceAttributes::HTTP_RESPONSE_STATUS_CODE] ?? '');
+                    $this->assertArrayNotHasKey(TraceAttributes::HTTP_METHOD, $attributes);
+                    $this->assertArrayNotHasKey(TraceAttributes::HTTP_STATUS_CODE, $attributes);
+                }
+            }
+        }
+    }
+    public function test_span_error(): void
+    {
+        $this->readableSpan->expects('getParentContext')->andReturn(SpanContext::getInvalid());
+        $this->readableSpan->expects('getDuration')->andReturn(123456789);
+        $spanData = Mockery::mock(SpanDataInterface::class);
+        $spanData->expects('getStatus')->andReturn(StatusData::create(StatusCode::STATUS_ERROR, 'error'));
+        $this->readableSpan->expects('toSpanData')->andReturn($spanData);
+        $this->readableSpan->expects('getKind')->andReturn(SpanKind::KIND_SERVER);
+        $this->readableSpan->expects('getAttribute')->with(TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE)->andReturn('transaction');
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_REQUEST_METHOD)->andReturn('POST');
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_RESPONSE_STATUS_CODE)->andReturn(400);
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_METHOD)->andReturnNull();
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_STATUS_CODE)->andReturnNull();
+        $this->responseTimeSpanProcessor->onEnd($this->readableSpan);
+        $this->reader->collect();
+        $metrics = $this->exporter->Collect();
+        // Check histogram
+        $this->assertCount(1, $metrics);
+        foreach ($metrics as $metric) {
+            $this->assertEquals('trace.service.response_time', $metric->name);
+            $this->assertEquals('ms', $metric->unit);
+            if ($metric->data instanceof Histogram) {
+                $this->assertEquals('Delta', $metric->data->temporality);
+                $this->assertCount(1, $metric->data->dataPoints);
+                foreach ($metric->data->dataPoints as $dataPoint) {
+                    $this->assertEquals(123.456789, $dataPoint->sum);
+                    $attributes = [];
+                    foreach ($dataPoint->attributes as $key => $value) {
+                        $attributes[$key] = $value;
+                    }
+                    $this->assertTrue($attributes['sw.is_error'] ?? false);
+                    $this->assertEquals('transaction', $attributes[TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE] ?? '');
+                    $this->assertEquals('POST', $attributes[TraceAttributes::HTTP_REQUEST_METHOD] ?? '');
+                    $this->assertEquals(400, $attributes[TraceAttributes::HTTP_RESPONSE_STATUS_CODE] ?? '');
+                    $this->assertArrayNotHasKey(TraceAttributes::HTTP_METHOD, $attributes);
+                    $this->assertArrayNotHasKey(TraceAttributes::HTTP_STATUS_CODE, $attributes);
+                }
+            }
+        }
+    }
+}

--- a/tests/Unit/Trace/SpanProcessor/ResponseTimeSpanProcessorTest.php
+++ b/tests/Unit/Trace/SpanProcessor/ResponseTimeSpanProcessorTest.php
@@ -279,9 +279,9 @@ class ResponseTimeSpanProcessorTest extends MockeryTestCase
         $spanData->expects('getStatus')->andReturn(StatusData::create(StatusCode::STATUS_UNSET, 'unset'));
         $this->readableSpan->expects('toSpanData')->andReturn($spanData);
         $this->readableSpan->expects('getKind')->andReturn(SpanKind::KIND_SERVER);
-        $this->readableSpan->expects('getAttribute')->with(TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE)->andReturn('transaction');
-        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_REQUEST_METHOD)->andReturn('GET');
-        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_RESPONSE_STATUS_CODE)->andReturn(200);
+        $this->readableSpan->expects('getAttribute')->with(TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE)->andReturnNull();
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_REQUEST_METHOD)->andReturnNull();
+        $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_RESPONSE_STATUS_CODE)->andReturnNull();
         $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_METHOD)->andReturnNull();
         $this->readableSpan->expects('getAttribute')->with(TraceAttributes::HTTP_STATUS_CODE)->andReturnNull();
         $this->responseTimeSpanProcessor->onEnd($this->readableSpan);
@@ -302,9 +302,9 @@ class ResponseTimeSpanProcessorTest extends MockeryTestCase
                         $attributes[$key] = $value;
                     }
                     $this->assertFalse($attributes['sw.is_error'] ?? true);
-                    $this->assertEquals('transaction', $attributes[TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE] ?? '');
-                    $this->assertEquals('GET', $attributes[TraceAttributes::HTTP_REQUEST_METHOD] ?? '');
-                    $this->assertEquals(200, $attributes[TraceAttributes::HTTP_RESPONSE_STATUS_CODE] ?? '');
+                    $this->assertArrayNotHasKey(TransactionNameSpanProcessor::TRANSACTION_NAME_ATTRIBUTE, $attributes);
+                    $this->assertArrayNotHasKey(TraceAttributes::HTTP_REQUEST_METHOD, $attributes);
+                    $this->assertArrayNotHasKey(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $attributes);
                     $this->assertArrayNotHasKey(TraceAttributes::HTTP_METHOD, $attributes);
                     $this->assertArrayNotHasKey(TraceAttributes::HTTP_STATUS_CODE, $attributes);
                 }


### PR DESCRIPTION
### Description of changes:
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
- Added ResponseTimeSpanProcessor to generate Response Time histogram
- Fixed meter provider so that request counts and response time can be exported
- Added tests
- Added `.env.dev` file
- Updated metrics description

### Related issues #
[NH-108337](https://swicloud.atlassian.net/browse/NH-108337)

[NH-108337]: https://swicloud.atlassian.net/browse/NH-108337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ