### PR TITLE
NH-112084 Reduced the scan scope

### DIFF
--- a/.github/workflows/reversinglabs.yml
+++ b/.github/workflows/reversinglabs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Package
-        run: zip -r scan.zip .
+        run: zip -r scan.zip ./examples ./src ./tests ./composer.json Makefile
       - name: Scan artifacts on the Portal
         id: rl-scan
         env:


### PR DESCRIPTION
### Description of changes:
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
- Reversinglabs scan complains the `.git` folder is included to the scan https://my.secure.software/solarwinds/reports/group/c4e85d4d-1ce0-440c-adf3-b7c014e5958e/report/apm-php/apm-php/0.0.1-beta.1/issues
- Reduced the scan scope

### Related issues #
[NH-112084](https://swicloud.atlassian.net/browse/NH-112084)