### PR TITLE
NH-133385: PHP followup: Fixed verbose logs

### DIFF
--- a/src/Trace/Sampler/BucketSettings.php
+++ b/src/Trace/Sampler/BucketSettings.php
@@ -21,4 +21,9 @@ class BucketSettings
     {
         return $this->rate;
     }
+
+    public function __toString(): string
+    {
+        return sprintf('{capacity=%.2f, rate=%.2f}', $this->capacity, $this->rate);
+    }
 }

--- a/src/Trace/Sampler/BucketSettings.php
+++ b/src/Trace/Sampler/BucketSettings.php
@@ -24,6 +24,6 @@ class BucketSettings
 
     public function __toString(): string
     {
-        return sprintf('{capacity=%.2f, rate=%.2f}', $this->capacity, $this->rate);
+        return sprintf('{capacity=%.2f rate=%.2f}', $this->capacity, $this->rate);
     }
 }

--- a/src/Trace/Sampler/Settings.php
+++ b/src/Trace/Sampler/Settings.php
@@ -49,7 +49,11 @@ class Settings
             'sampleRate' => $this->sampleRate,
             'sampleSource' => $this->sampleSource,
             'flags' => $this->flags,
-            'buckets' => $this->buckets,
+            'buckets' => implode(',', array_map(
+                fn($k, $v) => "$k=$v",
+                array_keys($this->buckets),
+                $this->buckets
+            )),
             'signatureKey' => $this->signatureKey,
             'timestamp' => $this->timestamp,
             'ttl' => $this->ttl,

--- a/src/Trace/Sampler/Settings.php
+++ b/src/Trace/Sampler/Settings.php
@@ -50,7 +50,7 @@ class Settings
             'sampleSource' => $this->sampleSource,
             'flags' => $this->flags,
             'buckets' => implode(',', array_map(
-                fn($k, $v) => "$k=$v",
+                fn ($k, $v) => "$k=$v",
                 array_keys($this->buckets),
                 $this->buckets
             )),

--- a/src/Trace/Sampler/TokenBucket.php
+++ b/src/Trace/Sampler/TokenBucket.php
@@ -108,7 +108,7 @@ class TokenBucket
         return false;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return sprintf('TokenBucket(capacity=%.2f, rate=%.2f)', $this->capacity, $this->rate);
     }

--- a/src/Trace/Sampler/TraceOptions.php
+++ b/src/Trace/Sampler/TraceOptions.php
@@ -92,7 +92,7 @@ class TraceOptions
         return $traceOptions;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $kvs = [
             TRIGGER_TRACE_KEY => $this->triggerTrace ? 'true' : null,

--- a/src/Trace/Sampler/TraceOptionsResponse.php
+++ b/src/Trace/Sampler/TraceOptionsResponse.php
@@ -10,7 +10,7 @@ class TraceOptionsResponse
     public ?TriggerTrace $triggerTrace = null;
     public ?array $ignored = null;
 
-    public function __toString()
+    public function __toString(): string
     {
         $kvs = [
             'auth' => $this->auth?->value,

--- a/src/Trace/Sampler/TraceOptionsWithResponse.php
+++ b/src/Trace/Sampler/TraceOptionsWithResponse.php
@@ -16,7 +16,7 @@ class TraceOptionsWithResponse extends TraceOptions
         $this->response = $response;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return parent::__toString() . ';' . $this->response;
     }

--- a/tests/Unit/Trace/Sampler/SettingsTest.php
+++ b/tests/Unit/Trace/Sampler/SettingsTest.php
@@ -157,7 +157,7 @@ class SettingsTest extends TestCase
         $this->assertSame(7, $data['sampleRate']);
         $this->assertSame(SampleSource::LocalDefault->value, $data['sampleSource']);
         $this->assertSame(0x1234, $data['flags']);
-        $this->assertSame(['a', 'b'], $data['buckets']);
+        $this->assertSame('0=a,1=b', $data['buckets']);
         $this->assertNull($data['signatureKey']);
         $this->assertSame(111, $data['timestamp']);
         $this->assertSame(222, $data['ttl']);
@@ -177,7 +177,7 @@ class SettingsTest extends TestCase
         $json = (string) $settings;
         $data = json_decode($json, true);
         $this->assertSame('', $data['signatureKey']);
-        $this->assertSame([], $data['buckets']);
+        $this->assertSame('', $data['buckets']);
     }
 
     public function test_merge_with_all_flags_and_edge_cases(): void


### PR DESCRIPTION
This pull request improves string representations across several classes related to trace sampling, making debugging and logging output more informative and consistent. The main changes involve implementing or updating the `__toString()` methods to provide clearer, more structured output.

**Improvements to string representations:**

* [`BucketSettings`](diffhunk://#diff-eba39c6474f7f164a2d18fd51580925b91923c1341580f3727af31f688bba0e8R24-R28): Added a `__toString()` method to output capacity and rate in a readable format.
* [`TokenBucket`](diffhunk://#diff-b35edf5c7d9e77ed484720ce8dacae7116c9446696f8b08cfb4726b6ec4f39f2L111-R111): Updated `__toString()` to specify a return type and output capacity and rate.
* [`Settings`](diffhunk://#diff-6257b40b5f9584190ab42cfc883c9deac5d858a8939f3b9dcb8fc470e874219bL52-R56): Enhanced the `__toString()` method to display the `buckets` property as a comma-separated list of key-value pairs instead of a raw array.

**Consistency and type safety:**

* `TraceOptions`, `TraceOptionsResponse`, `TraceOptionsWithResponse`: Updated `__toString()` methods to explicitly declare return types, ensuring consistency and improved type safety. [[1]](diffhunk://#diff-ae81418013b1fbbd3393e942db5ff880853810fd47d2041d1dd8997bcba964beL95-R95) [[2]](diffhunk://#diff-5d3c07488ec15136bc7a9279d1d3ba25f963d112a86760037864474017671c99L13-R13) [[3]](diffhunk://#diff-b44e4f13a480a9e184250add94e3d468ff6b66f90a1d7f3109245e86f453ac1cL19-R19)